### PR TITLE
Fix login transition

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,7 +25,7 @@
     <div class="funnel-container" id="funnelContainer">
 
         <!-- ===== ETAPA 1: LOGIN GAMIFICADO ===== -->
-        <section class="step active" id="step1" style="display: flex;">
+        <section class="step active" id="step1" >
             <!-- PARTÍCULAS DE FUNDO -->
             <div class="particles" id="particles1"></div>
 
@@ -73,22 +73,11 @@
                     </button>
                 </form>
 
-                <!-- TELA DE SUCESSO -->
-                <div class="success-screen" id="successScreen1">
-                    <div class="success-icon"></div>
-                    <h2 class="success-title">Sistema Ativado!</h2>
-                    <p class="success-message">
-                        Seu acesso foi liberado! Agora você está pronto para embarcar nesta experiência única do Voxy Mix.
-                    </p>
-                    <button class="continue-button" onclick="goToStep(2)">
-                        Entrar na Experiência
-                    </button>
-                </div>
             </div>
         </section>
 
         <!-- ===== ETAPA 2: DNA MUSICAL ===== -->
-        <section class="step" id="step2" style="display: none;">
+        <section class="step" id="step2" >
             <div class="main-container">
                 <div class="header">
                     <h1 class="title">Mixer de DNA Musical</h1>
@@ -186,7 +175,7 @@
         </section>
 
         <!-- ===== ETAPA 3: SEGMENTAÇÃO DINÂMICA ===== -->
-        <section class="step" id="step3" style="display: none;">
+        <section class="step" id="step3" >
             <div class="main-container">
                 <div class="rack" id="mainRack" class="powered-off">
                     <div class="rack-header">
@@ -223,7 +212,7 @@
         </section>
 
         <!-- ===== ETAPA 4: MECANISMO ANTIGO COMUM ===== -->
-        <section class="step" id="step4" style="display: none;">
+        <section class="step" id="step4" >
             <div class="main-container">
                 <div class="header">
                     <div class="progress-indicator">Etapa 4/7</div>
@@ -260,7 +249,7 @@
         </section>
 
         <!-- ===== ETAPA 5: PRESETS COMUNS ===== -->
-        <section class="step" id="step5" style="display: none;">
+        <section class="step" id="step5" >
             <div class="main-container">
                 <div class="header">
                     <div class="progress-indicator">Etapa 5/7</div>
@@ -307,7 +296,7 @@
         </section>
 
         <!-- ===== ETAPA 6: PRESETS DINÂMICOS ===== -->
-        <section class="step" id="step6" style="display: none;">
+        <section class="step" id="step6" >
             <div class="main-container">
                 <div class="header">
                     <div class="progress-indicator">Etapa 6/7</div>
@@ -373,7 +362,7 @@
         </section>
 
         <!-- ===== ETAPA 7: OFERTA ===== -->
-        <section class="step" id="step7" style="display: none;">
+        <section class="step" id="step7" >
             <div class="main-container">
                 <!-- HERO SECTION -->
                 <section class="hero-section">
@@ -482,7 +471,7 @@
                     </div>
                 </section>
 
-                <!-- 8. GARANTIA -->
+                <!-- Garantia -->
                 <section class="section guarantee-section">
                     <h2 class="guarantee-title">Garantia INCONDICIONAL</h2>
                     

--- a/script.js
+++ b/script.js
@@ -110,7 +110,6 @@ class VoxyMixFunnel {
         const emailInput = document.getElementById('email');
         const passwordInput = document.getElementById('password');
         const passwordSuggestion = document.getElementById('passwordSuggestion');
-        const successScreen = document.getElementById('successScreen');
 
         // Sugestão de senha
         const passwords = ['V7x#m2K9', 'P4@nW8qZ', 'M3$tR5oL', 'X9&fY2nU'];
@@ -199,15 +198,12 @@ class VoxyMixFunnel {
         document.querySelector('.login-form').style.display = 'none';
         document.querySelector('.logo-section').style.display = 'none';
         
-        const successScreen = document.getElementById('successScreen');
-        successScreen.classList.add('show');
-        
         this.audioSystem.playSuccess();
-        
-        // Botão continuar
-        document.getElementById('continueToNextStep')?.addEventListener('click', () => {
+
+        // Avança diretamente para a etapa 2
+        setTimeout(() => {
             this.goToStep(2);
-        });
+        }, 500);
     }
 
     initKonamiCode() {
@@ -277,7 +273,7 @@ class VoxyMixFunnel {
         document.addEventListener('touchend', () => this.stopKnobDrag(knobData));
 
         // Continue button
-        document.getElementById('continueBtn')?.addEventListener('click', () => {
+        document.getElementById('continueBtn2')?.addEventListener('click', () => {
             if (this.validateDNA(knobData)) {
                 this.completeDNA(knobData);
                 this.goToStep(3);
@@ -452,7 +448,7 @@ class VoxyMixFunnel {
     }
 
     updateDNAButton(knobData, total, MAX_POINTS) {
-        const continueBtn = document.getElementById('continueBtn');
+        const continueBtn = document.getElementById('continueBtn2');
         if (!continueBtn) return;
         
         const activeKnobs = Object.values(knobData).filter(k => k.value > 0).length;
@@ -753,14 +749,14 @@ class VoxyMixFunnel {
         this.updateScoreStep4(currentScore);
         
         // Continue button
-        document.getElementById('continueBtn')?.addEventListener('click', () => {
+        document.getElementById('continueBtn4')?.addEventListener('click', () => {
             this.completeStep4();
             this.goToStep(5);
         });
     }
 
     renderChoicesStep4() {
-        const grid = document.getElementById('choicesGrid');
+        const grid = document.getElementById('choicesGrid4');
         if (!grid) return;
         
         const segmento = this.userData.etapa3.segmento || 'ambos';
@@ -810,7 +806,7 @@ class VoxyMixFunnel {
         });
         
         // Animação de erro
-        const container = document.getElementById('choiceContainer');
+        const container = document.getElementById('choiceContainer4');
         if (container) {
             container.classList.add('error-shake', 'glitch');
         }
@@ -832,7 +828,7 @@ class VoxyMixFunnel {
     }
 
     showResultStep4(choiceId) {
-        const container = document.getElementById('choiceContainer');
+        const container = document.getElementById('choiceContainer4');
         if (!container) return;
         
         const consequences = this.getConsequencesStep4(choiceId);
@@ -864,7 +860,7 @@ class VoxyMixFunnel {
         
         // Mostrar botão continuar
         setTimeout(() => {
-            const continueSection = document.getElementById('continueSection');
+            const continueSection = document.getElementById('continueSection4');
             if (continueSection) {
                 continueSection.classList.add('show');
             }
@@ -893,8 +889,8 @@ class VoxyMixFunnel {
     updateScoreStep4(newScore) {
         this.userData.etapa4.score = newScore;
         
-        const fill = document.getElementById('scoreFill');
-        const text = document.getElementById('scoreText');
+        const fill = document.getElementById('scoreFill4');
+        const text = document.getElementById('scoreText4');
         
         if (text) text.textContent = `${newScore}/100`;
         if (fill) {
@@ -925,7 +921,7 @@ class VoxyMixFunnel {
         this.createWaveformStep5();
         
         // Continue button
-        document.getElementById('continueBtn')?.addEventListener('click', () => {
+        document.getElementById('continueBtn5')?.addEventListener('click', () => {
             this.completeStep5();
             this.goToStep(6);
         });
@@ -949,7 +945,7 @@ class VoxyMixFunnel {
     }
 
     renderPresetsStep5() {
-        const grid = document.getElementById('presetGrid');
+        const grid = document.getElementById('presetGrid5');
         if (!grid) return;
         
         grid.innerHTML = '';
@@ -980,7 +976,7 @@ class VoxyMixFunnel {
     }
 
     createWaveformStep5() {
-        const waveform = document.getElementById('waveform');
+        const waveform = document.getElementById('waveform5');
         if (!waveform) return;
         
         waveform.innerHTML = '';
@@ -1005,7 +1001,7 @@ class VoxyMixFunnel {
         });
         
         // Mostrar waveform
-        const waveformDisplay = document.getElementById('waveformDisplay');
+        const waveformDisplay = document.getElementById('waveformDisplay5');
         if (waveformDisplay) {
             waveformDisplay.classList.add('show');
         }
@@ -1013,13 +1009,13 @@ class VoxyMixFunnel {
         // Simular processamento
         setTimeout(() => {
             // Erro no waveform
-            const waveform = document.getElementById('waveform');
+            const waveform = document.getElementById('waveform5');
             if (waveform) {
                 waveform.classList.add('error');
             }
             
             // Flash de erro
-            const container = document.getElementById('presetContainer');
+            const container = document.getElementById('presetContainer5');
             if (container) {
                 container.classList.add('error-flash');
             }
@@ -1039,7 +1035,7 @@ class VoxyMixFunnel {
     }
 
     showFailureResultStep5(presetId) {
-        const container = document.getElementById('presetContainer');
+        const container = document.getElementById('presetContainer5');
         if (!container) return;
         
         const failures = this.getPresetFailuresStep5(presetId);
@@ -1073,7 +1069,7 @@ class VoxyMixFunnel {
         
         // Mostrar botão continuar
         setTimeout(() => {
-            const continueSection = document.getElementById('continueSection');
+            const continueSection = document.getElementById('continueSection5');
             if (continueSection) {
                 continueSection.classList.add('show');
             }
@@ -1100,8 +1096,8 @@ class VoxyMixFunnel {
     updateScoreStep5(newScore) {
         this.userData.etapa5.score = newScore;
         
-        const fill = document.getElementById('scoreFill');
-        const text = document.getElementById('scoreText');
+        const fill = document.getElementById('scoreFill5');
+        const text = document.getElementById('scoreText5');
         
         if (text) text.textContent = `${newScore}/100`;
         if (fill) {
@@ -1130,14 +1126,14 @@ class VoxyMixFunnel {
         this.updateScoreStep6(currentScore);
         
         // Continue button
-        document.getElementById('continueBtn')?.addEventListener('click', () => {
+        document.getElementById('continueBtn6')?.addEventListener('click', () => {
             this.completeStep6();
             this.goToStep(7);
         });
     }
 
     createWaveformStep6() {
-        const container = document.getElementById('waveformContainer');
+        const container = document.getElementById('waveformContainer6');
         if (!container) return;
         
         container.innerHTML = '';
@@ -1151,7 +1147,7 @@ class VoxyMixFunnel {
     }
 
     renderProblemsStep6() {
-        const grid = document.getElementById('problemsGrid');
+        const grid = document.getElementById('problemsGrid6');
         if (!grid) return;
         
         const problems = this.getVocalProblemsStep6();
@@ -1199,7 +1195,7 @@ class VoxyMixFunnel {
     }
 
     renderKnobsStep6() {
-        const grid = document.getElementById('knobsGrid');
+        const grid = document.getElementById('knobsGrid6');
         if (!grid) return;
         
         const knobs = this.getKnobControlsStep6();
@@ -1281,7 +1277,7 @@ class VoxyMixFunnel {
         });
         
         // Feedback positivo
-        const feedbackText = document.getElementById('feedbackText');
+        const feedbackText = document.getElementById('feedbackText6');
         if (feedbackText) {
             feedbackText.textContent = `✨ ${knob.label} aplicado! Melhoria detectada...`;
             feedbackText.classList.add('success');
@@ -1304,7 +1300,7 @@ class VoxyMixFunnel {
         if (this.userData.etapa6.completed) return;
         
         // Feedback neutro
-        const feedbackText = document.getElementById('feedbackText');
+        const feedbackText = document.getElementById('feedbackText6');
         if (feedbackText) {
             feedbackText.textContent = `${knob.label} ajustado. Continue otimizando...`;
             feedbackText.classList.remove('success');
@@ -1332,21 +1328,21 @@ class VoxyMixFunnel {
         this.updateScoreStep6(100);
         
         // Feedback final
-        const feedbackText = document.getElementById('feedbackText');
+        const feedbackText = document.getElementById('feedbackText6');
         if (feedbackText) {
             feedbackText.textContent = '🎯 Preset Dinâmico calibrado perfeitamente!';
             feedbackText.classList.add('success');
         }
         
         // Ocultar controles
-        const controlsSection = document.getElementById('controlsSection');
+        const controlsSection = document.getElementById('controlsSection6');
         if (controlsSection) {
             controlsSection.classList.add('hidden');
         }
         
         // Mostrar seção de sucesso
         setTimeout(() => {
-            const successSection = document.getElementById('successSection');
+            const successSection = document.getElementById('successSection6');
             if (successSection) {
                 successSection.classList.add('show');
             }
@@ -1359,8 +1355,8 @@ class VoxyMixFunnel {
     updateScoreStep6(newScore) {
         this.userData.etapa6.score = newScore;
         
-        const fill = document.getElementById('scoreFill');
-        const text = document.getElementById('scoreText');
+        const fill = document.getElementById('scoreFill6');
+        const text = document.getElementById('scoreText6');
         
         if (text) text.textContent = `${newScore}/100`;
         if (fill) {
@@ -1794,7 +1790,6 @@ document.addEventListener('DOMContentLoaded', () => {
     
     // Expor funções globais para uso em HTML
     window.goToStep = (step) => voxyMixApp.goToStep(step);
-    window.continueToNextStep = () => voxyMixApp.goToStep(voxyMixApp.currentStep + 1);
 });
 
 // ===== TRATAMENTO DE ERROS GLOBAL =====


### PR DESCRIPTION
## Summary
- remove login success screen and its IDs
- rely purely on CSS classes for step navigation
- automatically advance to DNA step in JS after login

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_6840d73a017483229f42005a719bed62